### PR TITLE
add docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "3.9"
+services:
+    node:
+        image: node:16.3.0-alpine
+        ports:
+            - 3000:3000
+        environment: 
+            - NODE_ENV=development
+            - MONGODB_URI=mongodb://mongo:27017/
+            - MONGODB_DB=crisis-news-development
+            - MONGODB_USER=root
+            - MONGODB_PASS=password
+
+        working_dir: /app
+        volumes:
+            - ./:/app
+        command: sh -c "npm ci && npm run dev"
+
+    mongo:
+        image: mongo
+        restart: always
+        environment:
+            MONGO_INITDB_ROOT_USERNAME: root
+            MONGO_INITDB_ROOT_PASSWORD: password
+        volumes:
+            - mongo_volume:/data/db
+
+    mongo-express:
+        image: mongo-express
+        restart: always
+        ports:
+            - 8081:8081
+        environment:
+            ME_CONFIG_MONGODB_SERVER: mongo
+            ME_CONFIG_MONGODB_PORT: 27017
+            ME_CONFIG_MONGODB_ADMINUSERNAME: root
+            ME_CONFIG_MONGODB_ADMINPASSWORD: password
+        depends_on:
+            - mongo
+
+volumes:
+    mongo_volume:


### PR DESCRIPTION
# 概要
`git clone` した後 `docker-compose up` で`localhost:3000`にアプリが立ち上がるように書きました。

# env
.envに書かれている環境変数もdocker-compose.ymlの方で定義してます。

# mongo-express
不要であれば消します。

# 使用したDocker

```
zonoise@zonoisenoMacBook-Air crisis-news-map-next % docker version
Client:
 Cloud integration: 1.0.17
 Version:           20.10.7
 API version:       1.41
 Go version:        go1.16.4
 Git commit:        f0df350
 Built:             Wed Jun  2 11:56:23 2021
 OS/Arch:           darwin/arm64
 Context:           desktop-linux
 Experimental:      true

Server: Docker Engine - Community
 Engine:
  Version:          20.10.7
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.13.15
  Git commit:       b0f5bc3
  Built:            Wed Jun  2 11:55:36 2021
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          1.4.6
  GitCommit:        d71fcd7d8303cbf684402823e425e9dd2e99285d
 runc:
  Version:          1.0.0-rc95
  GitCommit:        b9ee9c6314599f1b4a7f497e1f1f856fe433d3b7
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```